### PR TITLE
 Ensure file closing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,12 +5,15 @@ python:
   - 3.3
   - 3.4
   - 3.5
+  - 3.6
+  - 3.7
+  - 3.8
 
 install:
   - travis_retry pip install -r requirements.txt
   - travis_retry pip install coveralls
 
-script: make test
+script: PYTHONWARNINGS=always make test
 
 branches:
   only:

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,8 +2,6 @@ language: python
 
 python:
   - 2.7
-  - 3.3
-  - 3.4
   - 3.5
   - 3.6
   - 3.7

--- a/mdmail/api.py
+++ b/mdmail/api.py
@@ -98,7 +98,8 @@ class EmailContent(object):
     def _inline_css(self, html, css):
         if not css:
             default_css = os.path.join(os.path.dirname(__file__), 'default.css')
-            css = open(default_css, encoding='utf-8').read()
+            with open(default_css, encoding='utf-8') as f:
+                css = f.read()
         email_html_template = u"""
         <!doctype html>
         <html>


### PR DESCRIPTION
Hi,

Running tests with `PYTHONWARNINGS=always` on a project that depend of mdmail, I got:

```
…/lib/python3.8/site-packages/mdmail/api.py:101: ResourceWarning: unclosed file <_io.TextIOWrapper name='…/lib/python3.8/site-packages/mdmail/default.css' mode='r' encoding='utf-8'>
  css = open(default_css, encoding='utf-8').read()
```

So here is a quickfix.

While here, I updated the python versions that Travis should test:
- added 3.6 to 3.8, as they work well
- removed 3.3, as Travis doesn't provide it anymore:
   >  Unable to download 3.3 archive. The archive may not exist. Please consider a different version.
- removed 3.4, as lxml doesn't support it anymore:
    >  This lxml version requires Python 2.7, 3.5 or later.